### PR TITLE
Fix polygon has no method geojson

### DIFF
--- a/aeronet/__version__.py
+++ b/aeronet/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 0, 12)
+VERSION = (0, 0, 13)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/aeronet/dataset/vector/feature.py
+++ b/aeronet/dataset/vector/feature.py
@@ -4,7 +4,7 @@ import warnings
 import shapely
 import shapely.geometry
 from shapely.geometry import Polygon, MultiPolygon, GeometryCollection
-from shapely.geometry.polygon import orient
+from shapely.ops import orient
 
 from rasterio.warp import transform_geom
 
@@ -63,21 +63,11 @@ class Feature:
             f = self
 
         shape = f.shape
-        if isinstance(shape, MultiPolygon):
-            shape = MultiPolygon([orient(poly) for poly in shape])
-        elif isinstance(shape, Polygon):
+        try:
             shape = orient(shape)
-        elif isinstance(shape, GeometryCollection):
-            contours = []
-            for geo_object in shape:
-                if isinstance(geo_object, Polygon):
-                    contours.append(geo_object)
-                elif isinstance(geo_object, MultiPolygon):
-                    contours += list(geo_object)
-            shape = MultiPolygon([orient(poly) for poly in shape])
-        else:
+        except Exception as e:
             shape = Polygon()
-
+        
         f = Feature(shape, properties=f.properties)
         data = {
             'type': 'Feature',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 keras==2.2.4
 numpy>=1.15.4
 rasterio>=1.0.0
-shapely>=1.7a1
+shapely>=1.7.1
 opencv-python>=4.0.0
 tqdm>=4.36.1
 rtree>=0.8.3


### PR DESCRIPTION
Fix problem with orientation of empty polygon.
Also polygon orientation step is skipped now for the feature if the orient() throws exception.

Also FeatureCollection.save() now supports parameter indent from json.dump() to make line breaks. It makes file larger but helps to open it with some editors.